### PR TITLE
Removes 'public' accessibility from C# example as the entrypoint can be private

### DIFF
--- a/csharp.cs
+++ b/csharp.cs
@@ -1,1 +1,1 @@
-class A{public static void Main(){}}
+class A{static void Main(){}}


### PR DESCRIPTION
C# Main method can be private. See http://social.msdn.microsoft.com/Forums/en-CA/csharpgeneral/thread/9184c55b-4629-4fbf-ad77-2e96eadc4d62#7b6f4481-5d59-4e26-96dc-99a13cb2e3a0
