### PR TITLE
Compiles just fine without a return type (which defaults to 'int').

### DIFF
--- a/c.c
+++ b/c.c
@@ -1,1 +1,1 @@
-int main(){}
+main(){}


### PR DESCRIPTION
This is valid ANSI C and ISO C89.
