### PR TITLE
smaller go.go

### DIFF
--- a/go.go
+++ b/go.go
@@ -1,1 +1,1 @@
-package main;func main(){};
+package main;func main(){}


### PR DESCRIPTION
semicolons are inserted automatically by the lexer https://golang.org/doc/effective_go.html#semicolons