### PR TITLE
Replace (void){} with ;

### DIFF
--- a/c.c
+++ b/c.c
@@ -1,1 +1,1 @@
-int main(void){}
+int main;


### PR DESCRIPTION
`gcc -std=c99 -o c c.c` doesn't trigger any warning.