### PR TITLE
Reduce haskell_term by one character

### DIFF
--- a/haskell_term.hs
+++ b/haskell_term.hs
@@ -1,1 +1,1 @@
-main=print 0
+main=pure()


### PR DESCRIPTION
Since GHC 7.10 (base 4.8), Applicative became a member of Prelude, which
means we can access the wonderfully short function `pure` to shave off
one character (while also not printing anything).