### PR TITLE
Remove type from main (c and cpp)

### DIFF
--- a/c.c
+++ b/c.c
@@ -1,1 +1,1 @@
-int main;
+main;

--- a/cpp.cpp
+++ b/cpp.cpp
@@ -1,1 +1,1 @@
-int main(){}
+main(){}


### PR DESCRIPTION
In c and cpp, no return type defaults to `int`.

g++ does not complain at all about this (cpp).

gcc gives a warning (`type defaults to ‘int’ in declaration of ‘main’ [-Wimplicit-int]`), is this allowed? (c)