### PR TITLE
Add smallest possible diff file

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ To the extent possible under law, the author has waived all copyright and relate
 - [chicken](chicken.chicken)
 - [crystal](crystal.cr)
 - [Cascading Style Sheets .css](css.css)
+- [diff](c.patch)
 - [eiffel](eiffel.e)
 - [elixir](elixir.ex)
 - [Git commit](https://github.com/mathiasbynens/small/commit/63a7f20c7b442c21bd9b6d4a80fdbea77e59dc6b)

--- a/c.patch
+++ b/c.patch
@@ -1,0 +1,7 @@
+diff --git c.c c.c
+index f7fb591..c61f0be 100644
+--- c.c
++++ c.c
+@@ -1 +1 @@
+-int main;
++lint main;


### PR DESCRIPTION
Closes #122 

You can apply it with: `patch -p0 < c.patch`

There are smaller patches possible, but i think this is OK for now.

- the file name could be smaller, but i wanted to use a real file in this repo
- the change could be smaller. only changing 1 character in a line that only has 1 character

Feel free to improve in an additional PR!